### PR TITLE
Fixed: UnicodeEncodeError when the Services Display Name contains a unicode string

### DIFF
--- a/autoruns.py
+++ b/autoruns.py
@@ -944,7 +944,7 @@ class AutoRunsIngestModule(DataSourceIngestModule):
 
                             art = file.newDataArtifact(artType, Arrays.asList(
                                 BlackboardAttribute(attributeIdServiceKeyName, moduleName, str(servicekey.getName())),
-                                BlackboardAttribute(attributeIdServiceDisplayName, moduleName, str(display_name)),
+                                BlackboardAttribute(attributeIdServiceDisplayName, moduleName, display_name),
                                 BlackboardAttribute(attributeIdServiceTimestamp, moduleName, str(timestamp)),
                                 BlackboardAttribute(attributeIdServiceStartup, moduleName, self.serviceStartup[startup]),
                                 BlackboardAttribute(attributeIdServiceType, moduleName, self.serviceTypes[service_type]),


### PR DESCRIPTION
When the Display Name of Service contains a Unicode string, an error occurred and the process was interrupted by trying to encode the unicode string to ascii by `str(display_name)`.

Perhaps this error occurs in many languages of the Windows environment.

Therefore, I changed display_name not to convert to ascii.

The Autopsy error log is as follows.
```
2022-06-19 22:30:16.384 org.sleuthkit.autopsy.ingest.IngestJobPipeline logErrorMessage
SEVERE: Autoruns experienced an error during analysis (data source = l2807_C.e01, objId = 1, pipeline id = 0, ingest job id = 1)
Traceback (most recent call last):
  File "C:\Users\yasul\AppData\Roaming\autopsy\python_modules\Autopsy-Autoruns-main\autoruns.py", line 313, in process
    self.process_Services(dataSource, progressBar)
  File "C:\Users\yasul\AppData\Roaming\autopsy\python_modules\Autopsy-Autoruns-main\autoruns.py", line 945, in process_Services
    art = file.newDataArtifact(artType, Arrays.asList(
UnicodeEncodeError: 'ascii' codec can't encode characters in position 14-17: ordinal not in range(128)

	org.python.core.codecs.strict_errors(codecs.java:206)
	sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	java.lang.reflect.Method.invoke(Method.java:498)
	org.python.core.JavaFunc.__call__(Py.java:2895)
	org.python.core.PyObject.__call__(PyObject.java:433)
	org.python.core.codecs.encoding_error(codecs.java:1537)
	org.python.core.codecs.PyUnicode_EncodeIntLimited(codecs.java:1210)
	org.python.core.codecs.PyUnicode_EncodeASCII(codecs.java:1169)
	org.python.core.codecs.encode(codecs.java:163)
	org.python.core.PyString.encode(PyString.java:3995)
	org.python.core.PyString.encode(PyString.java:3987)
	org.python.core.PyUnicode.unicode___str__(PyUnicode.java:681)
	org.python.core.PyUnicode.__str__(PyUnicode.java:676)
	org.python.core.PyString.str_new(PyString.java:172)
	org.python.core.PyString$exposed___new__.new_impl(Unknown Source)
	org.python.core.PyType.invokeNew(PyType.java:1119)
	org.python.core.PyType.type___call__(PyType.java:2399)
	org.python.core.PyType.__call__(PyType.java:2389)
	org.python.core.PyObject.__call__(PyObject.java:461)
	org.python.core.PyObject.__call__(PyObject.java:465)
	autoruns$py.process_Services$18(C:/Users/yasul/AppData/Roaming/autopsy/python_modules/Autopsy-Autoruns-main/autoruns.py:855)
	autoruns$py.call_function(C:/Users/yasul/AppData/Roaming/autopsy/python_modules/Autopsy-Autoruns-main/autoruns.py)
	org.python.core.PyTableCode.call(PyTableCode.java:173)
	org.python.core.PyBaseCode.call(PyBaseCode.java:168)
	org.python.core.PyFunction.__call__(PyFunction.java:437)
	org.python.core.PyMethod.__call__(PyMethod.java:156)
	autoruns$py.process$15(C:/Users/yasul/AppData/Roaming/autopsy/python_modules/Autopsy-Autoruns-main/autoruns.py:351)
	autoruns$py.call_function(C:/Users/yasul/AppData/Roaming/autopsy/python_modules/Autopsy-Autoruns-main/autoruns.py)
	org.python.core.PyTableCode.call(PyTableCode.java:173)
	org.python.core.PyBaseCode.call(PyBaseCode.java:306)
	org.python.core.PyBaseCode.call(PyBaseCode.java:197)
	org.python.core.PyFunction.__call__(PyFunction.java:485)
	org.python.core.PyMethod.instancemethod___call__(PyMethod.java:237)
	org.python.core.PyMethod.__call__(PyMethod.java:228)
	org.python.core.PyMethod.__call__(PyMethod.java:218)
	org.python.core.PyMethod.__call__(PyMethod.java:213)
	org.python.core.PyObject._jcallexc(PyObject.java:3565)
	org.python.core.PyObject._jcall(PyObject.java:3598)
	org.python.proxies.autoruns$AutoRunsIngestModule$26.process(Unknown Source)
	org.sleuthkit.autopsy.ingest.DataSourceIngestPipeline$DataSourcePipelineModule.executeTask(DataSourceIngestPipeline.java:93)
	org.sleuthkit.autopsy.ingest.DataSourceIngestPipeline$DataSourcePipelineModule.executeTask(DataSourceIngestPipeline.java:72)
	org.sleuthkit.autopsy.ingest.IngestTaskPipeline.executeTask(IngestTaskPipeline.java:220)
	org.sleuthkit.autopsy.ingest.IngestJobPipeline.execute(IngestJobPipeline.java:1085)
	org.sleuthkit.autopsy.ingest.DataSourceIngestTask.execute(DataSourceIngestTask.java:41)
	org.sleuthkit.autopsy.ingest.IngestManager$ExecuteIngestJobTasksTask.run(IngestManager.java:1019)
	java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	java.util.concurrent.FutureTask.run(FutureTask.java:266)
	java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	java.lang.Thread.run(Thread.java:748)
2022-06-19 22:30:16.388 org.sleuthkit.autopsy.ingest.IngestJobPipeline logInfoMessage
INFO: Finished first stage analysis (data source = l2807_C.e01, objId = 1, pipeline id = 0, ingest job id = 1)
```